### PR TITLE
Add flag for disabling accelerate3d off

### DIFF
--- a/drivers/virtualbox/virtualbox.go
+++ b/drivers/virtualbox/virtualbox.go
@@ -72,6 +72,7 @@ type Driver struct {
 	NoShare               bool
 	DNSProxy              bool
 	NoVTXCheck            bool
+	NoAccelerate3DOff     bool
 	ShareFolder           string
 }
 
@@ -200,6 +201,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "Disable checking for the availability of hardware virtualization before the vm is started",
 			EnvVar: "VIRTUALBOX_NO_VTX_CHECK",
 		},
+		mcnflag.BoolFlag{
+			Name:   "virtualbox-no-accelerate3d-off",
+			Usage:  "Disable turning off the possibly missing 3D graphics acceleration before the vm is started",
+			EnvVar: "VIRTUALBOX_NO_ACCELERATE3D_OFF",
+		},
 		mcnflag.StringFlag{
 			EnvVar: "VIRTUALBOX_SHARE_FOLDER",
 			Name:   "virtualbox-share-folder",
@@ -255,6 +261,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.NoShare = flags.Bool("virtualbox-no-share")
 	d.DNSProxy = !flags.Bool("virtualbox-no-dns-proxy")
 	d.NoVTXCheck = flags.Bool("virtualbox-no-vtx-check")
+	d.NoAccelerate3DOff = flags.Bool("virtualbox-no-accelerate3d-off")
 	d.ShareFolder = flags.String("virtualbox-share-folder")
 
 	return nil
@@ -415,9 +422,11 @@ func (d *Driver) CreateVM() error {
 		"--hwvirtex", "on",
 		"--nestedpaging", "on",
 		"--largepages", "on",
-		"--vtxvpid", "on",
-		"--accelerate3d", "off",
-		"--boot1", "dvd"}
+		"--vtxvpid", "on"}
+	if !d.NoAccelerate3DOff {
+		modifyFlags = append(modifyFlags, "--accelerate3d", "off")
+	}
+	modifyFlags = append(modifyFlags, "--boot1", "dvd")
 
 	if d.version > 6 {
 		modifyFlags = append(modifyFlags, "--natlocalhostreachable1", hostLoopbackReachable)

--- a/drivers/virtualbox/virtualbox_test.go
+++ b/drivers/virtualbox/virtualbox_test.go
@@ -574,6 +574,37 @@ func TestCreateVMWithSpecificNatNicType(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCreateVMWithoutAccelerate3D(t *testing.T) {
+	shareName, shareDir := getShareDriveAndName()
+
+	modifyVMcommand := "vbm modifyvm default --firmware bios --bioslogofadein off --bioslogofadeout off --bioslogodisplaytime 0 --biosbootmenu disabled --ostype Linux26_64 --cpus 1 --memory 1024 --acpi on --ioapic on --rtcuseutc on --natdnshostresolver1 off --natdnsproxy1 on --cpuhotplug off --pae on --hpet on --hwvirtex on --nestedpaging on --largepages on --vtxvpid on --boot1 dvd"
+	if runtime.GOOS == "windows" && runtime.GOARCH == "386" {
+		modifyVMcommand += " --longmode on"
+	}
+
+	driver := NewDriver("default", "path")
+	driver.NoAccelerate3DOff = true
+	mockCalls(t, driver, []Call{
+		{"CopyIsoToMachineDir path default http://b2d.org", "", nil},
+		{"Generate path/machines/default/id_rsa", "", nil},
+		{"Create 20000 path/machines/default/id_rsa.pub path/machines/default/disk.vmdk", "", nil},
+		{"vbm createvm --basefolder path/machines/default --name default --register", "", nil},
+		{modifyVMcommand, "", nil},
+		{"vbm modifyvm default --nic1 nat --nictype1 82540EM --cableconnected1 on", "", nil},
+		{"vbm storagectl default --name SATA --add sata --hostiocache on", "", nil},
+		{"vbm storageattach default --storagectl SATA --port 0 --device 0 --type dvddrive --medium path/machines/default/boot2docker.iso", "", nil},
+		{"vbm storageattach default --storagectl SATA --port 1 --device 0 --type hdd --medium path/machines/default/disk.vmdk", "", nil},
+		{"vbm guestproperty set default /VirtualBox/GuestAdd/SharedFolders/MountPrefix /", "", nil},
+		{"vbm guestproperty set default /VirtualBox/GuestAdd/SharedFolders/MountDir /", "", nil},
+		{"vbm sharedfolder add default --name " + shareName + " --hostpath " + shareDir + " --automount", "", nil},
+		{"vbm setextradata default VBoxInternal2/SharedFoldersEnableSymlinksCreate/" + shareName + " 1", "", nil},
+	})
+
+	err := driver.CreateVM()
+
+	assert.NoError(t, err)
+}
+
 func TestStart(t *testing.T) {
 	driver := NewDriver("default", "path")
 	mockCalls(t, driver, []Call{


### PR DESCRIPTION
Some of the new VirtualBox versions have an issue with AMD GPU.

So make it possible to omit this flag, from the VBoxManage cmd.