### PR TITLE
[machine]:windows node setup

### DIFF
--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -37,7 +37,7 @@ const (
 	defaultVLanID               = 0
 	defaultDisableDynamicMemory = false
 	defaultSwitchID             = "c08cb7b8-9b3c-408e-8e30-5e16a3aeb444"
-	defaultServerImageUrl       = "https://serverimagebuilder.blob.core.windows.net/windowsimagevhdx/GI-W11-001.vhdx"
+	defaultServerImageUrl       = "https://minikubevhdimagebuider.blob.core.windows.net/minikubevhdimage/GI-W11-001.vhdx"
 )
 
 // NewDriver creates a new Hyper-v driver with default settings.

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -37,7 +37,7 @@ const (
 	defaultVLanID               = 0
 	defaultDisableDynamicMemory = false
 	defaultSwitchID             = "c08cb7b8-9b3c-408e-8e30-5e16a3aeb444"
-	defaultServerImageUrl       = "https://minikubevhdimagebuider.blob.core.windows.net/minikubevhdimage/GI-W11-001.vhdx"
+	defaultServerImageUrl       = "https://minikubevhdimagebuider.blob.core.windows.net/minikubevhdimage/GI-W11-002.vhdx"
 )
 
 // NewDriver creates a new Hyper-v driver with default settings.

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -37,7 +37,7 @@ const (
 	defaultVLanID               = 0
 	defaultDisableDynamicMemory = false
 	defaultSwitchID             = "c08cb7b8-9b3c-408e-8e30-5e16a3aeb444"
-	defaultServerImageUrl       = "https://minikubevhdimagebuider.blob.core.windows.net/minikubevhdimage/GI-W11-002.vhdx"
+	defaultServerImageUrl       = "https://minikubevhdimagebuider.blob.core.windows.net/minikubevhdimage/WIN-SER-2025.vhdx"
 )
 
 // NewDriver creates a new Hyper-v driver with default settings.
@@ -207,7 +207,8 @@ func (d *Driver) Create() error {
 	b2dutils := mcnutils.NewB2dUtils(d.StorePath)
 
 	if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
-		if err := b2dutils.CopyWindowsIsoToMachineDir(d.WindowsVHDUrl, d.MachineName); err != nil {
+		d.SSHUser = "Administrator"
+		if err := b2dutils.CopyWindowsVHDToMachineDir(d.WindowsVHDUrl, d.MachineName); err != nil {
 			return err
 		}
 	} else {
@@ -217,6 +218,7 @@ func (d *Driver) Create() error {
 	}
 
 	log.Infof("Creating SSH key...")
+
 	if err := ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		return err
 	}
@@ -300,7 +302,7 @@ func (d *Driver) Create() error {
 	if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
 		if err := cmd("Hyper-V\\Add-VMHardDiskDrive",
 			"-VMName", d.MachineName,
-			"-Path", quote(d.ResolveStorePath("GI-W11-001.vhdx")),
+			"-Path", quote(d.ResolveStorePath("WIN-SER-2025.vhdx")),
 			"-ControllerType", "SCSI"); err != nil {
 			return err
 		}

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -577,10 +577,11 @@ func writeSSHKeyToVHDX(vhdxPath, publicSSHKeyPath string) error {
 	driveLetter := regex.ReplaceAllString(output, "")
 
 	if driveLetter == "" {
+		log.Debugf("No drive letter assigned to VHDX")
 		return errors.New("no drive letter assigned to VHDX")
 	}
 
-	mountDir := strings.TrimSpace(driveLetter) + ":\\"
+	mountDir := strings.TrimSpace(driveLetter) + ":" + string(os.PathSeparator)
 
 	defer func() {
 		if unmountErr := cmd("Dismount-DiskImage", "-ImagePath", quote(vhdxPath)); unmountErr != nil {

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -235,7 +235,7 @@ func (d *Driver) Create() error {
 
 	if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
 		log.Infof("Adding SSH key to the VHDX...")
-		if err := d.makeDiskImage(); err != nil {
+		if err := mcnutils.WriteSSHKeyToVHDX(d.ResolveStorePath(mcnutils.GetDefaultServerImageFilename()), d.publicSSHKeyPath()); err != nil {
 			log.Errorf("Error creating disk image: %s", err)
 			return err
 		}
@@ -507,11 +507,6 @@ func (d *Driver) GetIP() (string, error) {
 
 func (d *Driver) publicSSHKeyPath() string {
 	return d.GetSSHKeyPath() + ".pub"
-}
-
-// makeDiskImage bundles ssh key in a vhd
-func (d *Driver) makeDiskImage() error {
-	return mcnutils.WriteSSHKeyToVHDX(d.ResolveStorePath(mcnutils.GetDefaultServerImageFilename()), d.publicSSHKeyPath())
 }
 
 // generateDiskImage creates a small fixed vhd, put the tar in, convert to dynamic, then resize

--- a/drivers/hyperv/hyperv.go
+++ b/drivers/hyperv/hyperv.go
@@ -301,9 +301,8 @@ func (d *Driver) Create() error {
 		}
 	}
 
-	if mcnutils.ConfigGuest.GetGuestOS() == "windows" {
-		// === Windows ===
-	} else {
+	if mcnutils.ConfigGuest.GetGuestOS() != "windows" {
+		log.Infof("Attaching ISO and disk...")
 		if err := cmd("Hyper-V\\Set-VMDvdDrive",
 			"-VMName", d.MachineName,
 			"-Path", quote(d.ResolveStorePath("boot2docker.iso"))); err != nil {

--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -61,7 +61,7 @@ func hypervAvailable() error {
 	}
 
 	resp := parseLines(stdout)
-	if resp == nil || len(resp) == 0 || resp[0] != "Hyper-V" {
+	if len(resp) == 0 || resp[0] != "Hyper-V" {
 		return ErrNotInstalled
 	}
 

--- a/drivers/hyperv/powershell.go
+++ b/drivers/hyperv/powershell.go
@@ -106,7 +106,7 @@ func isWindowsAdministrator() (bool, error) {
 }
 
 func quote(text string) string {
-	return fmt.Sprintf("'%s'", text)
+	return fmt.Sprintf(`"%s"`, text)
 }
 
 func toMb(value int) string {

--- a/libmachine/drivers/utils.go
+++ b/libmachine/drivers/utils.go
@@ -34,10 +34,6 @@ func GetSSHClientFromDriver(d Driver) (ssh.Client, error) {
 }
 
 func RunSSHCommandFromDriver(d Driver, command string) (string, error) {
-	// if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
-	// 	return "", fmt.Errorf("SSH commands are not supported on Windows")
-	// }
-
 	client, err := GetSSHClientFromDriver(d)
 	if err != nil {
 		return "", err

--- a/libmachine/drivers/utils.go
+++ b/libmachine/drivers/utils.go
@@ -10,40 +10,24 @@ import (
 
 func GetSSHClientFromDriver(d Driver) (ssh.Client, error) {
 	address, err := d.GetSSHHostname()
-	log.Debugf("GetSSHHostname: %s", address)
 	if err != nil {
 		return nil, err
 	}
 
 	port, err := d.GetSSHPort()
-	log.Debugf("GetSSHPort: %d", port)
 	if err != nil {
 		return nil, err
 	}
 
 	var auth *ssh.Auth
-	log.Debugf("GetSSHKeyPath: %s", d.GetSSHKeyPath())
-
-	if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
-		if d.GetSSHKeyPath() == "" {
-			auth = &ssh.Auth{}
-		} else {
-			auth = &ssh.Auth{
-				Keys:      []string{d.GetSSHKeyPath()},
-				Passwords: []string{"password"}, // Add a password if needed
-			}
-		}
+	if d.GetSSHKeyPath() == "" {
+		auth = &ssh.Auth{}
 	} else {
-		if d.GetSSHKeyPath() == "" {
-			auth = &ssh.Auth{}
-		} else {
-			auth = &ssh.Auth{
-				Keys: []string{d.GetSSHKeyPath()},
-			}
+		auth = &ssh.Auth{
+			Keys: []string{d.GetSSHKeyPath()},
 		}
 	}
 
-	log.Debugf("GetSSHUsername: %s", d.GetSSHUsername())
 	client, err := ssh.NewClient(d.GetSSHUsername(), address, port, auth)
 	return client, err
 

--- a/libmachine/drivers/utils.go
+++ b/libmachine/drivers/utils.go
@@ -34,6 +34,10 @@ func GetSSHClientFromDriver(d Driver) (ssh.Client, error) {
 }
 
 func RunSSHCommandFromDriver(d Driver, command string) (string, error) {
+	if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
+		return "", fmt.Errorf("SSH commands are not supported on Windows")
+	}
+
 	client, err := GetSSHClientFromDriver(d)
 	if err != nil {
 		return "", err

--- a/libmachine/drivers/utils.go
+++ b/libmachine/drivers/utils.go
@@ -10,33 +10,49 @@ import (
 
 func GetSSHClientFromDriver(d Driver) (ssh.Client, error) {
 	address, err := d.GetSSHHostname()
+	log.Debugf("GetSSHHostname: %s", address)
 	if err != nil {
 		return nil, err
 	}
 
 	port, err := d.GetSSHPort()
+	log.Debugf("GetSSHPort: %d", port)
 	if err != nil {
 		return nil, err
 	}
 
 	var auth *ssh.Auth
-	if d.GetSSHKeyPath() == "" {
-		auth = &ssh.Auth{}
+	log.Debugf("GetSSHKeyPath: %s", d.GetSSHKeyPath())
+
+	if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
+		if d.GetSSHKeyPath() == "" {
+			auth = &ssh.Auth{}
+		} else {
+			auth = &ssh.Auth{
+				Keys:      []string{d.GetSSHKeyPath()},
+				Passwords: []string{"password"}, // Add a password if needed
+			}
+		}
 	} else {
-		auth = &ssh.Auth{
-			Keys: []string{d.GetSSHKeyPath()},
+		if d.GetSSHKeyPath() == "" {
+			auth = &ssh.Auth{}
+		} else {
+			auth = &ssh.Auth{
+				Keys: []string{d.GetSSHKeyPath()},
+			}
 		}
 	}
 
+	log.Debugf("GetSSHUsername: %s", d.GetSSHUsername())
 	client, err := ssh.NewClient(d.GetSSHUsername(), address, port, auth)
 	return client, err
 
 }
 
 func RunSSHCommandFromDriver(d Driver, command string) (string, error) {
-	if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
-		return "", fmt.Errorf("SSH commands are not supported on Windows")
-	}
+	// if mcnutils.ConfigGuestOSUtil.GetGuestOS() == "windows" {
+	// 	return "", fmt.Errorf("SSH commands are not supported on Windows")
+	// }
 
 	client, err := GetSSHClientFromDriver(d)
 	if err != nil {

--- a/libmachine/examples/main.go
+++ b/libmachine/examples/main.go
@@ -37,7 +37,7 @@ func create() {
 		return
 	}
 
-	h, err := client.NewHost("virtualbox", data)
+	h, err := client.NewHost("virtualbox", "linux", data)
 	if err != nil {
 		log.Error(err)
 		return
@@ -82,7 +82,7 @@ func streaming() {
 		return
 	}
 
-	h, err := client.NewHost("virtualbox", data)
+	h, err := client.NewHost("virtualbox", "linux", data)
 	if err != nil {
 		log.Error(err)
 		return

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -44,6 +44,7 @@ type Host struct {
 	HostOptions   *Options
 	Name          string
 	RawDriver     []byte `json:"-"`
+	GuestOS       string
 }
 
 type Options struct {

--- a/libmachine/host/host.go
+++ b/libmachine/host/host.go
@@ -44,7 +44,7 @@ type Host struct {
 	HostOptions   *Options
 	Name          string
 	RawDriver     []byte `json:"-"`
-	GuestOS       string
+	Guest         Guest
 }
 
 type Options struct {
@@ -60,6 +60,12 @@ type Metadata struct {
 	ConfigVersion int
 	DriverName    string
 	HostOptions   Options
+}
+
+type Guest struct {
+	Name    string
+	Version string
+	URL     string
 }
 
 func ValidateHostName(name string) bool {

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/machine/libmachine/check"
 	"github.com/docker/machine/libmachine/drivers"
 	"github.com/docker/machine/libmachine/drivers/plugin/localbinary"
-	"github.com/docker/machine/libmachine/drivers/rpc"
+	rpcdriver "github.com/docker/machine/libmachine/drivers/rpc"
 	"github.com/docker/machine/libmachine/engine"
 	"github.com/docker/machine/libmachine/host"
 	"github.com/docker/machine/libmachine/log"
@@ -28,7 +28,8 @@ import (
 
 type API interface {
 	io.Closer
-	NewHost(driverName string, rawDriver []byte) (*host.Host, error)
+	NewHost(driverName string, guestOS string, rawDriver []byte) (*host.Host, error)
+	DefineGuest(h *host.Host)
 	Create(h *host.Host) error
 	persist.Store
 	GetMachinesDir() string
@@ -53,7 +54,7 @@ func NewClient(storePath, certsDir string) *Client {
 	}
 }
 
-func (api *Client) NewHost(driverName string, rawDriver []byte) (*host.Host, error) {
+func (api *Client) NewHost(driverName string, guestOS string, rawDriver []byte) (*host.Host, error) {
 	driver, err := api.clientDriverFactory.NewRPCClientDriver(driverName, rawDriver)
 	if err != nil {
 		return nil, err
@@ -64,6 +65,7 @@ func (api *Client) NewHost(driverName string, rawDriver []byte) (*host.Host, err
 		Name:          driver.GetMachineName(),
 		Driver:        driver,
 		DriverName:    driver.DriverName(),
+		GuestOS:       guestOS,
 		HostOptions: &host.Options{
 			AuthOptions: &auth.Options{
 				CertDir:          api.certsDir,
@@ -113,11 +115,15 @@ func (api *Client) Load(name string) (*host.Host, error) {
 	return h, nil
 }
 
+func (api *Client) DefineGuest(h *host.Host) {
+	mcnutils.SetGuestOSUtil(h.GuestOS)
+}
+
 // Create is the wrapper method which covers all of the boilerplate around
 // actually creating, provisioning, and persisting an instance in the store.
 func (api *Client) Create(h *host.Host) error {
 	if err := cert.BootstrapCertificates(h.AuthOptions()); err != nil {
-		return fmt.Errorf("Error generating certificates: %s", err)
+		return fmt.Errorf("error generating certificates: %s", err)
 	}
 
 	log.Info("Running pre-create checks...")
@@ -129,13 +135,13 @@ func (api *Client) Create(h *host.Host) error {
 	}
 
 	if err := api.Save(h); err != nil {
-		return fmt.Errorf("Error saving host to store before attempting creation: %s", err)
+		return fmt.Errorf("error saving host to store before attempting creation: %s", err)
 	}
 
 	log.Info("Creating machine...")
 
 	if err := api.performCreate(h); err != nil {
-		return fmt.Errorf("Error creating machine: %s", err)
+		return fmt.Errorf("error creating machine: %s", err)
 	}
 
 	log.Debug("Reticulating splines...")
@@ -145,11 +151,11 @@ func (api *Client) Create(h *host.Host) error {
 
 func (api *Client) performCreate(h *host.Host) error {
 	if err := h.Driver.Create(); err != nil {
-		return fmt.Errorf("Error in driver during machine creation: %s", err)
+		return fmt.Errorf("error in driver during machine creation: %s", err)
 	}
 
 	if err := api.Save(h); err != nil {
-		return fmt.Errorf("Error saving host to store after attempting creation: %s", err)
+		return fmt.Errorf("error saving host to store after attempting creation: %s", err)
 	}
 
 	// TODO: Not really a fan of just checking "none" or "ci-test" here.
@@ -159,24 +165,24 @@ func (api *Client) performCreate(h *host.Host) error {
 
 	log.Info("Waiting for machine to be running, this may take a few minutes...")
 	if err := mcnutils.WaitFor(drivers.MachineInState(h.Driver, state.Running)); err != nil {
-		return fmt.Errorf("Error waiting for machine to be running: %s", err)
+		return fmt.Errorf("error waiting for machine to be running: %s", err)
 	}
 
 	log.Info("Detecting operating system of created instance...")
 	provisioner, err := provision.DetectProvisioner(h.Driver)
 	if err != nil {
-		return fmt.Errorf("Error detecting OS: %s", err)
+		return fmt.Errorf("error detecting OS: %s", err)
 	}
 
 	log.Infof("Provisioning with %s...", provisioner.String())
 	if err := provisioner.Provision(*h.HostOptions.SwarmOptions, *h.HostOptions.AuthOptions, *h.HostOptions.EngineOptions); err != nil {
-		return fmt.Errorf("Error running provisioning: %s", err)
+		return fmt.Errorf("error running provisioning: %s", err)
 	}
 
 	// We should check the connection to docker here
 	log.Info("Checking connection to Docker...")
 	if _, _, err = check.DefaultConnChecker.Check(h, false); err != nil {
-		return fmt.Errorf("Error checking the host: %s", err)
+		return fmt.Errorf("error checking the host: %s", err)
 	}
 
 	log.Info("Docker is up and running!")

--- a/libmachine/libmachine.go
+++ b/libmachine/libmachine.go
@@ -28,7 +28,7 @@ import (
 
 type API interface {
 	io.Closer
-	NewHost(driverName string, guestOS string, rawDriver []byte) (*host.Host, error)
+	NewHost(driverName string, guest host.Guest, rawDriver []byte) (*host.Host, error)
 	DefineGuest(h *host.Host)
 	Create(h *host.Host) error
 	persist.Store
@@ -54,7 +54,7 @@ func NewClient(storePath, certsDir string) *Client {
 	}
 }
 
-func (api *Client) NewHost(driverName string, guestOS string, rawDriver []byte) (*host.Host, error) {
+func (api *Client) NewHost(driverName string, guest host.Guest, rawDriver []byte) (*host.Host, error) {
 	driver, err := api.clientDriverFactory.NewRPCClientDriver(driverName, rawDriver)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (api *Client) NewHost(driverName string, guestOS string, rawDriver []byte) 
 		Name:          driver.GetMachineName(),
 		Driver:        driver,
 		DriverName:    driver.DriverName(),
-		GuestOS:       guestOS,
+		Guest:         guest,
 		HostOptions: &host.Options{
 			AuthOptions: &auth.Options{
 				CertDir:          api.certsDir,
@@ -116,7 +116,7 @@ func (api *Client) Load(name string) (*host.Host, error) {
 }
 
 func (api *Client) DefineGuest(h *host.Host) {
-	mcnutils.SetGuestOSUtil(h.GuestOS)
+	mcnutils.SetGuestUtil(h.Guest.Name, h.Guest.URL)
 }
 
 // Create is the wrapper method which covers all of the boilerplate around

--- a/libmachine/libmachinetest/fake_api.go
+++ b/libmachine/libmachinetest/fake_api.go
@@ -20,7 +20,7 @@ func (api *FakeAPI) Close() error {
 	return nil
 }
 
-func (api *FakeAPI) NewHost(driverName string, rawDriver []byte) (*host.Host, error) {
+func (api *FakeAPI) NewHost(driverName string, guestOS string, rawDriver []byte) (*host.Host, error) {
 	return nil, nil
 }
 

--- a/libmachine/mcnutils/b2d.go
+++ b/libmachine/mcnutils/b2d.go
@@ -456,7 +456,10 @@ func (b *B2dUtils) UpdateVHDCache(defaultVHDUrl string) error {
 
 		filePath := filepath.Join(b.imgCachePath, defaultServerImageFilename)
 
-		err := DownloadVHDX(defaultVHDUrl, filePath, 16) // Download using 16 parts
+		fmt.Printf("\n")
+		fmt.Printf("    * Downloading and caching Windows Server VHD image...\n")
+		fmt.Printf("    * This may take a while...\n")
+		err := DownloadVHDX(defaultVHDUrl, filePath, 16, 1) // Download using 16 parts
 
 		if err != nil {
 			return fmt.Errorf("Error: %v", err)

--- a/libmachine/mcnutils/b2d.go
+++ b/libmachine/mcnutils/b2d.go
@@ -24,7 +24,7 @@ import (
 const (
 	defaultURL                 = "https://api.github.com/repos/boot2docker/boot2docker/releases"
 	defaultISOFilename         = "boot2docker.iso"
-	defaultServerImageFilename = "GI-W11-001.vhdx"
+	defaultServerImageFilename = "WIN-SER-2025.vhdx"
 	defaultVolumeIDOffset      = int64(0x8028)
 	versionPrefix              = "-v"
 	defaultVolumeIDLength      = 32
@@ -525,7 +525,7 @@ func (b *B2dUtils) CopyIsoToMachineDir(isoURL, machineName string) error {
 	return b.DownloadISO(machineDir, b.filename(), downloadURL)
 }
 
-func (b *B2dUtils) CopyWindowsIsoToMachineDir(VHDUrl, machineName string) error {
+func (b *B2dUtils) CopyWindowsVHDToMachineDir(VHDUrl, machineName string) error {
 
 	if err := b.UpdateVHDCache(VHDUrl); err != nil {
 		return err

--- a/libmachine/mcnutils/b2d.go
+++ b/libmachine/mcnutils/b2d.go
@@ -22,11 +22,13 @@ import (
 )
 
 const (
-	defaultURL            = "https://api.github.com/repos/boot2docker/boot2docker/releases"
-	defaultISOFilename    = "boot2docker.iso"
-	defaultVolumeIDOffset = int64(0x8028)
-	versionPrefix         = "-v"
-	defaultVolumeIDLength = 32
+	defaultURL                          = "https://api.github.com/repos/boot2docker/boot2docker/releases"
+	defaultISOFilename                  = "boot2docker.iso"
+	defaultWindowsISOFilename           = "SERVER_EVAL_x64FRE_en-us.iso"
+	defaultWindowsAnswerFileISOFilename = "auto-install.iso"
+	defaultVolumeIDOffset               = int64(0x8028)
+	versionPrefix                       = "-v"
+	defaultVolumeIDLength               = 32
 )
 
 var (
@@ -356,6 +358,10 @@ func NewB2dUtils(storePath string) *B2dUtils {
 	}
 }
 
+func (b *B2dUtils) GetImgCachePath() string {
+	return b.imgCachePath
+}
+
 // DownloadISO downloads boot2docker ISO image for the given tag and save it at dest.
 func (b *B2dUtils) DownloadISO(dir, file, isoURL string) error {
 	log.Infof("Downloading %s from %s...", b.path(), isoURL)
@@ -464,6 +470,28 @@ func (b *B2dUtils) CopyIsoToMachineDir(isoURL, machineName string) error {
 	}
 
 	return b.DownloadISO(machineDir, b.filename(), downloadURL)
+}
+
+func (b *B2dUtils) CopyWindowsIsoToMachineDir(machineName string) error {
+
+	machineDir := filepath.Join(b.storePath, "machines", machineName)
+
+	windowsMachineIsoPath := filepath.Join(machineDir, "SERVER_EVAL_x64FRE_en-us.iso")
+	answerFilePath := filepath.Join(machineDir, "auto-install.iso")
+
+	// cached location of the windows iso
+	windowsIsoPath := filepath.Join(b.imgCachePath, "SERVER_EVAL_x64FRE_en-us.iso")
+	// cached location of the answer file
+	answerFile := filepath.Join(b.imgCachePath, "auto-install.iso")
+
+	log.Infof("Copying %s to %s...", windowsIsoPath, windowsMachineIsoPath)
+	err := CopyFile(windowsIsoPath, windowsMachineIsoPath)
+	if err != nil {
+		return err
+	}
+	log.Infof("Copying %s to %s...", answerFile, answerFilePath)
+	return CopyFile(answerFile, answerFilePath)
+
 }
 
 // isLatest checks the latest release tag and

--- a/libmachine/mcnutils/b2d.go
+++ b/libmachine/mcnutils/b2d.go
@@ -24,7 +24,7 @@ import (
 const (
 	defaultURL                 = "https://api.github.com/repos/boot2docker/boot2docker/releases"
 	defaultISOFilename         = "boot2docker.iso"
-	defaultServerImageFilename = "WIN-SER-2025.vhdx"
+	defaultServerImageFilename = "hybrid-minikube-windows-server.vhdx"
 	defaultVolumeIDOffset      = int64(0x8028)
 	versionPrefix              = "-v"
 	defaultVolumeIDLength      = 32

--- a/libmachine/mcnutils/b2d.go
+++ b/libmachine/mcnutils/b2d.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -621,4 +622,65 @@ func MakeDiskImage(publicSSHKeyPath string) (*bytes.Buffer, error) {
 	}
 
 	return buf, nil
+}
+
+// function to return defaultServerImageFilename
+func GetDefaultServerImageFilename() string {
+	return defaultServerImageFilename
+}
+
+func WriteSSHKeyToVHDX(vhdxPath, publicSSHKeyPath string) error {
+	mountDir := "D:\\"
+	sshDir := mountDir + "ProgramData\\ssh\\"
+	adminAuthKeys := sshDir + "administrators_authorized_keys"
+
+	pubKey, err := ioutil.ReadFile(publicSSHKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read public SSH key: %w", err)
+	}
+
+	if err := mountVHDX(vhdxPath); err != nil {
+		return fmt.Errorf("failed to mount VHDX: %w", err)
+	}
+
+	if err := os.MkdirAll(sshDir, 0755); err != nil {
+		return fmt.Errorf("failed to create SSH directory: %w", err)
+	}
+
+	if err := ioutil.WriteFile(adminAuthKeys, pubKey, 0644); err != nil {
+		return fmt.Errorf("failed to write public key: %w", err)
+	}
+
+	cmd := exec.Command("icacls.exe", adminAuthKeys, "/inheritance:r", "/grant", "Administrators:F", "/grant", "SYSTEM:F")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to set permissions: %w", err)
+	}
+
+	if err := unmountVHDX(vhdxPath); err != nil {
+		return fmt.Errorf("failed to unmount VHDX: %w", err)
+	}
+
+	return nil
+}
+
+func mountVHDX(vhdxPath string) error {
+	cmd := exec.Command("powershell", "-Command", fmt.Sprintf(
+		"Mount-DiskImage -ImagePath '%s' -StorageType VHDX -PassThru | Get-Disk | Set-Disk -IsReadOnly $false",
+		vhdxPath,
+	))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func unmountVHDX(vhdxPath string) error {
+	cmd := exec.Command("powershell", "-Command", fmt.Sprintf(
+		"Dismount-DiskImage -ImagePath '%s'",
+		vhdxPath,
+	))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }

--- a/libmachine/mcnutils/b2d_test.go
+++ b/libmachine/mcnutils/b2d_test.go
@@ -207,10 +207,12 @@ func (m *mockReleaseGetter) download(dir, file, isoURL string) error {
 }
 
 type mockISO struct {
-	isopath string
-	exist   bool
-	ver     string
-	verCh   <-chan string
+	isopath  string
+	exist    bool
+	ver      string
+	vhdpath  string
+	vhdexist bool
+	verCh    <-chan string
 }
 
 func (m *mockISO) path() string {
@@ -219,6 +221,14 @@ func (m *mockISO) path() string {
 
 func (m *mockISO) exists() bool {
 	return m.exist
+}
+
+func (m *mockISO) pathVHD() string {
+	return m.vhdpath
+}
+
+func (m *mockISO) hasVHD() bool {
+	return m.vhdexist
 }
 
 func (m *mockISO) version() (string, error) {

--- a/libmachine/mcnutils/download_vhd.go
+++ b/libmachine/mcnutils/download_vhd.go
@@ -1,0 +1,125 @@
+package mcnutils
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/docker/machine/libmachine/log"
+)
+
+type ProgressWriter struct {
+	Total      int64
+	Downloaded int64
+	mu         sync.Mutex
+}
+
+func (pw *ProgressWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	pw.mu.Lock()
+	pw.Downloaded += int64(n)
+	pw.PrintProgress()
+	pw.mu.Unlock()
+	return n, nil
+}
+
+func (pw *ProgressWriter) PrintProgress() {
+	fmt.Printf("\rDownloading... %d/%d bytes complete", pw.Downloaded, pw.Total)
+}
+
+func DownloadPart(url string, start, end int64, partFileName string, pw *ProgressWriter, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Infof("Error creating request: %v", err)
+		return
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Infof("Error downloading part: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		log.Infof("Error: expected status 206 Partial Content, got %d", resp.StatusCode)
+		return
+	}
+
+	partFile, err := os.Create(partFileName)
+	if err != nil {
+		log.Infof("Error creating part file: %v", err)
+		return
+	}
+	defer partFile.Close()
+
+	buf := make([]byte, 32*1024) // 32 KB buffer
+	_, err = io.CopyBuffer(io.MultiWriter(partFile, pw), resp.Body, buf)
+	if err != nil {
+		log.Infof("Error saving part: %v", err)
+		return
+	}
+}
+
+func DownloadVHDX(url string, filePath string, numParts int) error {
+	resp, err := http.Head(url)
+	if err != nil {
+		return fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status: %s", resp.Status)
+	}
+
+	totalSize := resp.ContentLength
+	partSize := totalSize / int64(numParts)
+
+	pw := &ProgressWriter{Total: totalSize}
+	var wg sync.WaitGroup
+
+	partFiles := make([]string, numParts)
+	for i := 0; i < numParts; i++ {
+		start := int64(i) * partSize
+		end := start + partSize - 1
+		if i == numParts-1 {
+			end = totalSize - 1
+		}
+
+		partFileName := fmt.Sprintf("part-%d.tmp", i)
+		partFiles[i] = partFileName
+
+		wg.Add(1)
+		go DownloadPart(url, start, end, partFileName, pw, &wg)
+	}
+
+	wg.Wait()
+
+	out, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer out.Close()
+
+	for _, partFileName := range partFiles {
+		partFile, err := os.Open(partFileName)
+		if err != nil {
+			return fmt.Errorf("failed to open part file: %w", err)
+		}
+
+		_, err = io.Copy(out, partFile)
+		partFile.Close()
+		if err != nil {
+			return fmt.Errorf("failed to merge part file: %w", err)
+		}
+
+		os.Remove(partFileName)
+	}
+
+	log.Infof("\nDownload complete")
+	return nil
+}

--- a/libmachine/mcnutils/download_vhd.go
+++ b/libmachine/mcnutils/download_vhd.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,90 +18,166 @@ type ProgressWriter struct {
 	Total      int64
 	Downloaded int64
 	mu         sync.Mutex
+	TargetName string
+}
+
+func NewProgressWriter(total int64, targetName string) *ProgressWriter {
+	return &ProgressWriter{Total: total, TargetName: targetName}
 }
 
 func (pw *ProgressWriter) Write(p []byte) (int, error) {
 	n := len(p)
 	pw.mu.Lock()
 	pw.Downloaded += int64(n)
-	pw.PrintProgress()
+	pw.printProgress()
 	pw.mu.Unlock()
 	return n, nil
 }
 
-func (pw *ProgressWriter) PrintProgress() {
-	fmt.Printf("\r        > %s...: %d / %d bytes complete \t", defaultServerImageFilename, pw.Downloaded, pw.Total)
+func (pw *ProgressWriter) printProgress() {
+	// Overwrite the same line with \r
+	fmt.Printf("\r        > %s: %d / %d bytes complete", pw.TargetName, pw.Downloaded, pw.Total)
 }
 
-func DownloadPart(url string, start, end int64, partFileName string, pw *ProgressWriter, wg *sync.WaitGroup, retryLimit int) error {
-	defer wg.Done()
+// copyLocalFile copies from a local source path to destination, reporting progress.
+func copyLocalFile(srcPath, dstPath string) error {
+	srcFile, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("failed to open local source file %q: %w", srcPath, err)
+	}
+	defer srcFile.Close()
 
+	// Get total size
+	info, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat local source file %q: %w", srcPath, err)
+	}
+	totalSize := info.Size()
+
+	outFile, err := os.Create(dstPath)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file %q: %w", dstPath, err)
+	}
+	defer outFile.Close()
+
+	pw := NewProgressWriter(totalSize, filepath.Base(dstPath))
+	// Use TeeReader: read from srcFile, write to pw (for progress), and to outFile
+	_, err = io.Copy(outFile, io.TeeReader(srcFile, pw))
+	if err != nil {
+		return fmt.Errorf("error copying local file to %q: %w", dstPath, err)
+	}
+
+	// Final newline after progress
+	fmt.Printf("\n")
+	log.Infof("\t> Local copy complete: %s\n", dstPath)
+	return nil
+}
+
+// DownloadPart downloads a byte-range [start,end] of the URL into a temporary part file.
+// On error, it returns the error; progress for the range is reported via pw.
+// The caller goroutine must call wg.Done() exactly once.
+func DownloadPart(urlStr string, start, end int64, partFileName string, pw *ProgressWriter, retryLimit int) error {
 	var resp *http.Response
+	var err error
 
 	// Retry loop for downloading a part
 	for retries := 0; retries <= retryLimit; retries++ {
-		req, err := http.NewRequest("GET", url, nil)
-		if err != nil {
-			log.Errorf("Error creating request: %v", err)
-			return err
+		req, errReq := http.NewRequest("GET", urlStr, nil)
+		if errReq != nil {
+			log.Errorf("Error creating request: %v", errReq)
+			return errReq
 		}
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
 
 		resp, err = http.DefaultClient.Do(req)
 		if err != nil {
-			log.Errorf("Error downloading part: %v", err)
-			// Retry after waiting a bit
-			time.Sleep(time.Duration(2<<retries) * time.Second) // Exponential backoff
+			log.Errorf("Error downloading part (attempt %d): %v", retries+1, err)
+			// Exponential backoff before retry
+			time.Sleep(time.Duration(1<<uint(retries)) * time.Second)
 			continue
 		}
-		defer resp.Body.Close()
 
+		// If we get Partial Content, proceed to save
 		if resp.StatusCode == http.StatusPartialContent {
-			partFile, err := os.Create(partFileName)
-			if err != nil {
-				log.Errorf("Error creating part file: %v", err)
-				return err
+			partFile, errCreate := os.Create(partFileName)
+			if errCreate != nil {
+				log.Errorf("Error creating part file: %v", errCreate)
+				resp.Body.Close()
+				return errCreate
 			}
-			defer partFile.Close()
-
+			// Copy with progress
 			buf := make([]byte, 32*1024) // 32 KB buffer
-			_, err = io.CopyBuffer(io.MultiWriter(partFile, pw), resp.Body, buf)
-			if err != nil {
-				log.Errorf("Error saving part: %v", err)
-				return err
+			_, errCopy := io.CopyBuffer(io.MultiWriter(partFile, pw), resp.Body, buf)
+			partFile.Close()
+			resp.Body.Close()
+			if errCopy != nil {
+				log.Errorf("Error saving part: %v", errCopy)
+				return errCopy
 			}
-			return nil // Successful download, exit retry loop
+			return nil // success
 		}
 
-		// If server does not return expected status, retry
+		// Unexpected status => retry
 		log.Errorf("Error: expected status 206 Partial Content, got %d", resp.StatusCode)
-		// Retry after waiting
-		time.Sleep(time.Duration(2<<retries) * time.Second) // Exponential backoff
+		resp.Body.Close()
+		time.Sleep(time.Duration(1<<uint(retries)) * time.Second)
 	}
 
-	// If all retries fail, return an error
 	log.Errorf("Failed to download part after %d retries", retryLimit)
 	return fmt.Errorf("failed to download part after %d retries", retryLimit)
 }
 
-func DownloadVHDX(url string, filePath string, numParts int, retryLimit int) error {
-	resp, err := http.Head(url)
-	if err != nil {
-		return fmt.Errorf("failed to get file info: %w", err)
+// DownloadVHDX downloads a VHD from a URL or copies from a local path if detected.
+//   - urlStr: can be HTTP(S) URL or a local filesystem path (absolute or relative), or file:// URI.
+//   - filePath: destination path to write the VHD.
+//   - numParts: for HTTP downloads, number of parallel parts; ignored for local copy.
+//   - retryLimit: retry count per part.
+//
+// It returns an error on failure.
+func DownloadVHDX(urlStr string, filePath string, numParts int, retryLimit int) error {
+	// First, check if urlStr is a local file path or file:// URI.
+	if u, err := url.Parse(urlStr); err == nil {
+		if u.Scheme == "file" {
+			// file:// URI: extract path
+			localPath := u.Path
+			// On Windows, file:///C:/path yields u.Path="/C:/path". Strip leading slash.
+			if strings.HasPrefix(localPath, "/") && os.PathSeparator == '\\' && len(localPath) > 2 && localPath[1] == ':' {
+				localPath = localPath[1:]
+			}
+			return copyLocalFile(localPath, filePath)
+		}
 	}
+	// If no scheme or non-file scheme, check if it's a path existing on disk:
+	if fi, err := os.Stat(urlStr); err == nil && !fi.IsDir() {
+		// Treat as local file
+		return copyLocalFile(urlStr, filePath)
+	}
+
+	// Otherwise assume HTTP(S) URL:
+	// First, HEAD to get total size
+	resp, err := http.Head(urlStr)
+	if err != nil {
+		return fmt.Errorf("failed to get file info from URL %q: %w", urlStr, err)
+	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("bad status: %s", resp.Status)
+		return fmt.Errorf("bad status from HEAD %q: %s", urlStr, resp.Status)
+	}
+	totalSize := resp.ContentLength
+	if totalSize <= 0 {
+		return fmt.Errorf("unknown content length for URL %q", urlStr)
 	}
 
-	totalSize := resp.ContentLength
+	// For progress display: use base name of destination
+	pw := NewProgressWriter(totalSize, filepath.Base(filePath))
+
+	// Partition download into numParts
 	partSize := totalSize / int64(numParts)
-
-	pw := &ProgressWriter{Total: totalSize}
 	var wg sync.WaitGroup
-
+	var muErr sync.Mutex
+	downloadErrors := make([]error, 0, numParts)
 	partFiles := make([]string, numParts)
-	var downloadErrors []error
 
 	for i := 0; i < numParts; i++ {
 		start := int64(i) * partSize
@@ -106,48 +185,54 @@ func DownloadVHDX(url string, filePath string, numParts int, retryLimit int) err
 		if i == numParts-1 {
 			end = totalSize - 1
 		}
-
-		partFileName := fmt.Sprintf("part-%d.tmp", i)
+		partFileName := fmt.Sprintf("%s.part-%d.tmp", filePath, i)
 		partFiles[i] = partFileName
 
 		wg.Add(1)
-		go func(i int) {
-			err := DownloadPart(url, start, end, partFileName, pw, &wg, retryLimit)
-			if err != nil {
-				downloadErrors = append(downloadErrors, fmt.Errorf("failed to download part %d: %w", i, err))
+		go func(idx int, s, e int64, pfn string) {
+			defer wg.Done()
+			errPart := DownloadPart(urlStr, s, e, pfn, pw, retryLimit)
+			if errPart != nil {
+				muErr.Lock()
+				downloadErrors = append(downloadErrors, fmt.Errorf("part %d: %w", idx, errPart))
+				muErr.Unlock()
 			}
-		}(i)
+		}(i, start, end, partFileName)
 	}
 
+	// Wait for all parts
 	wg.Wait()
 
-	// If there are any errors during download, return them
 	if len(downloadErrors) > 0 {
-		return fmt.Errorf("download failed for the following parts: %v", downloadErrors)
+		// Clean up partial files
+		for _, pfn := range partFiles {
+			os.Remove(pfn)
+		}
+		return fmt.Errorf("download failed for parts: %v", downloadErrors)
 	}
 
-	// Proceed with merging the parts as before
-	out, err := os.Create(filePath)
+	// Merge parts
+	outFile, err := os.Create(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
+		return fmt.Errorf("failed to create destination file %q: %w", filePath, err)
 	}
-	defer out.Close()
+	defer outFile.Close()
 
-	for _, partFileName := range partFiles {
-		partFile, err := os.Open(partFileName)
-		if err != nil {
-			return fmt.Errorf("failed to open part file: %w", err)
+	for _, pfn := range partFiles {
+		f, errOpen := os.Open(pfn)
+		if errOpen != nil {
+			return fmt.Errorf("failed to open part file %q: %w", pfn, errOpen)
 		}
-
-		_, err = io.Copy(out, partFile)
-		partFile.Close()
-		if err != nil {
-			return fmt.Errorf("failed to merge part file: %w", err)
+		_, errCopy := io.Copy(outFile, f)
+		f.Close()
+		if errCopy != nil {
+			return fmt.Errorf("failed to merge part file %q: %w", pfn, errCopy)
 		}
-
-		os.Remove(partFileName)
+		os.Remove(pfn)
 	}
 
-	log.Infof("\n\r\t> Download complete")
+	// Final newline after progress
+	fmt.Printf("\n")
+	log.Infof("\t> Download complete: %s\n", filePath)
 	return nil
 }

--- a/libmachine/mcnutils/utils.go
+++ b/libmachine/mcnutils/utils.go
@@ -17,26 +17,6 @@ type MultiError struct {
 	Errs []error
 }
 
-// var ConfigGuestOSUtil *GuestOSUtil
-
-// type GuestOSUtil struct {
-// 	os string
-// }
-
-// func SetGuestOSUtil(guestOS string) {
-// 	ConfigGuestOSUtil = &GuestOSUtil{
-// 		os: guestOS,
-// 	}
-// }
-
-// func (g *GuestOSUtil) GetGuestOS() string {
-// 	if g == nil {
-// 		log.Debugf("GuestOSUtil is not initialized")
-// 		return "unknown"
-// 	}
-// 	return g.os
-// }
-
 type GuestUtil struct {
 	os     string
 	vhdUrl string

--- a/libmachine/mcnutils/utils.go
+++ b/libmachine/mcnutils/utils.go
@@ -24,13 +24,16 @@ type GuestOSUtil struct {
 }
 
 func SetGuestOSUtil(guestOS string) {
-	log.Debugf("==== we are being called")
 	ConfigGuestOSUtil = &GuestOSUtil{
 		os: guestOS,
 	}
 }
 
 func (g *GuestOSUtil) GetGuestOS() string {
+	if g == nil {
+		log.Debugf("GuestOSUtil is not initialized")
+		return "unknown"
+	}
 	return g.os
 }
 

--- a/libmachine/mcnutils/utils.go
+++ b/libmachine/mcnutils/utils.go
@@ -9,10 +9,29 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/docker/machine/libmachine/log"
 )
 
 type MultiError struct {
 	Errs []error
+}
+
+var ConfigGuestOSUtil *GuestOSUtil
+
+type GuestOSUtil struct {
+	os string
+}
+
+func SetGuestOSUtil(guestOS string) {
+	log.Debugf("==== we are being called")
+	ConfigGuestOSUtil = &GuestOSUtil{
+		os: guestOS,
+	}
+}
+
+func (g *GuestOSUtil) GetGuestOS() string {
+	return g.os
 }
 
 func (e MultiError) Error() string {

--- a/libmachine/mcnutils/utils.go
+++ b/libmachine/mcnutils/utils.go
@@ -17,24 +17,56 @@ type MultiError struct {
 	Errs []error
 }
 
-var ConfigGuestOSUtil *GuestOSUtil
+// var ConfigGuestOSUtil *GuestOSUtil
 
-type GuestOSUtil struct {
-	os string
+// type GuestOSUtil struct {
+// 	os string
+// }
+
+// func SetGuestOSUtil(guestOS string) {
+// 	ConfigGuestOSUtil = &GuestOSUtil{
+// 		os: guestOS,
+// 	}
+// }
+
+// func (g *GuestOSUtil) GetGuestOS() string {
+// 	if g == nil {
+// 		log.Debugf("GuestOSUtil is not initialized")
+// 		return "unknown"
+// 	}
+// 	return g.os
+// }
+
+type GuestUtil struct {
+	os     string
+	vhdUrl string
 }
 
-func SetGuestOSUtil(guestOS string) {
-	ConfigGuestOSUtil = &GuestOSUtil{
-		os: guestOS,
+// ConfigGuest is the package-level singleton for GuestUtil
+var ConfigGuest *GuestUtil
+
+func SetGuestUtil(guestOS, vhdUrl string) {
+	ConfigGuest = &GuestUtil{
+		os:     guestOS,
+		vhdUrl: vhdUrl,
 	}
+	log.Debugf("SetGuestUtil: os=%s, vhdUrl=%s", guestOS, vhdUrl)
 }
 
-func (g *GuestOSUtil) GetGuestOS() string {
+func (g *GuestUtil) GetGuestOS() string {
 	if g == nil {
-		log.Debugf("GuestOSUtil is not initialized")
+		log.Debugf("GuestUtil is not initialized")
 		return "unknown"
 	}
 	return g.os
+}
+
+func (g *GuestUtil) GetVHDUrl() string {
+	if g == nil {
+		log.Debugf("GuestUtil is not initialized")
+		return ""
+	}
+	return g.vhdUrl
 }
 
 func (e MultiError) Error() string {
@@ -111,7 +143,7 @@ func WaitForSpecificOrError(f func() (bool, error), maxAttempts int, waitInterva
 		}
 		time.Sleep(waitInterval)
 	}
-	return fmt.Errorf("Maximum number of retries (%d) exceeded", maxAttempts)
+	return fmt.Errorf("maximum number of retries (%d) exceeded", maxAttempts)
 }
 
 func WaitForSpecific(f func() bool, maxAttempts int, waitInterval time.Duration) error {

--- a/libmachine/ssh/client.go
+++ b/libmachine/ssh/client.go
@@ -168,14 +168,14 @@ func (client *NativeClient) dialSuccess() bool {
 	return true
 }
 
-func (client *NativeClient) session(command string) (*ssh.Client, *ssh.Session, error) {
+func (client *NativeClient) session(_ string) (*ssh.Client, *ssh.Session, error) {
 	if err := mcnutils.WaitFor(client.dialSuccess); err != nil {
-		return nil, nil, fmt.Errorf("Error attempting SSH client dial: %s", err)
+		return nil, nil, fmt.Errorf("error attempting SSH client dial: %s", err)
 	}
 
 	conn, err := ssh.Dial("tcp", net.JoinHostPort(client.Hostname, strconv.Itoa(client.Port)), &client.Config)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Mysterious error dialing TCP for SSH (we already succeeded at least once) : %s", err)
+		return nil, nil, fmt.Errorf("mysterious error dialing TCP for SSH (we already succeeded at least once): %s", err)
 	}
 	session, err := conn.NewSession()
 


### PR DESCRIPTION
To test this PR follow the steps below 

**Prerequisites (local machine)**

- Local clones of:
1. minikube-machine with the branch for this [PR](https://github.com/minikube-machine/machine/pull/13) 
2. minikube with the branch for this [PR](https://github.com/bobsira/minikube/pull/4)
- Optional: [windows-node-image-builder repo](https://github.com/bobsira/windows-node-image-builder) if you want to build a custom VHD: 

### 1) Prepare local modules (temporary local replace)

Open` go.mod` in your local `minikube `repo and temporarily replace the `github.com/docker/machine` module with your local `minikube-machine` path.

**Before (example upstream replacement)**
`github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20240815173309-ffb6b643c381`

**Temporary local replace( use a Windows absolute path)**
```
- github.com/docker/machine => github.com/minikube-machine/machine v0.0.0-20240815173309-ffb6b643c381
+ github.com/docker/machine => c:/dev/mini-machine/machine
```
Important: This replace is only for local testing. Remove or revert it before committing/pushing.

### 2) Build minikube

From the minikube repo root build with make (repo uses make target)
```
# execute this in git bash 
make
```
You should now have minikube.exe in the repo out directory

### 3) Start a hybrid cluster (elevated PowerShell)

**Start using the default (built-in) VHD**

`.\minikube.exe start --kubernetes-version=v1.33.0 -n 2 --node-os='[linux,windows]' `

**Start using a custom VHD (remote or local)**

`--windows-vhd-ur`l accepts remote URLs or local absolute paths:

**Remote**
`.\minikube.exe start --kubernetes-version=v1.32.3 -n 2 --node-os='[linux,windows]' --windows-vhd-url='https://<your-storage>/hybrid-minikube-windows-server.vhdx' `
**Local path**
`.\minikube.exe start --kubernetes-version=v1.32.3 -n 2 --node-os='[linux,windows]' --windows-vhd-url='C:\vhd\hybrid-minikube-windows-server.vhdx'`

### 4) What to expect
- minikube start provisions a Linux control plane VM and a Windows worker VM.
- VM provisioned from a prebuilt VHD
- `kubectl get nodes -o wide` should show two nodes with OS labels: one linux, one windows.

**Setting up the cluster**
<img width="953" height="522" alt="minikube_pic" src="https://github.com/user-attachments/assets/e5a92df3-ecd3-49e1-8c9a-801653198128" />

**Verify your cluster**
<img width="927" height="133" alt="cluster" src="https://github.com/user-attachments/assets/a35cacad-44fa-4ce4-95b8-eb71b08e1119" />
